### PR TITLE
Change source for poetry

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 ARG USERNAME=vscode
 
 USER vscode
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+RUN curl -sSL https://install.python-poetry.org | python -
 
 
 RUN mkdir -p /home/$USERNAME/.vscode-server/extensions \


### PR DESCRIPTION
fix(poetryInstall) Changed source for curl installation of poetry, as the previous one does not work now

Now it is as in https://python-poetry.org/docs/ 